### PR TITLE
Release 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,13 @@ URI TEDx is a WordPress theme designed for the University of Rhode Island's TEDx
 
 It is designed to be evergreen, and replaces the [uri-tedx-2018](https://github.com/uriweb/uri-tedx-2018) annual theme.
 
-## What's new in 2.3.0
+## What's new in 3.0
 
-URI TEDx 2.3 is a minor release focused on style adjustments.
+* Removes Google Tag Manager entirely
 
-* Updates evergreen speakers page styles
-* Adds styles for 2019 speakers page, previously in the WordPress customizer
-* Changes header and footer "Speakers" link to "Presenters"
-* Adjusts Talks post styles, including better support for non-square bio pictures
-* Removes non-functioning YouTube video statistics on Talks posts
+> Note: Installing this version without another means of GTM or GA injection will cease all analytics tracking. Think carefully!
 
-For complete details, see the [commit history](https://github.com/uriweb/uri-tedx/pull/29/commits) and the [issue tracker](https://github.com/uriweb/uri-tedx/issues).
+For complete details, see the [commit history](https://github.com/uriweb/uri-tedx/pull/31/commits) and the [issue tracker](https://github.com/uriweb/uri-tedx/issues).
 
 ## How do I get set up?
 

--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ Contributors: Brandon Fuller
 Tags: themes  
 Requires at least: 4.0  
 Tested up to: 6.1  
-Stable tag: 2.3.0  
+Stable tag: 3.0.0  

--- a/functions.php
+++ b/functions.php
@@ -274,37 +274,6 @@ endif;
 
 add_action( 'wp_head', 'uri_tedx_open_graph' );
 
-
-/**
- * Set the Google Tag Manager property ID
- *
- * @return str
- */
-function uri_tedx_gtm_value() {
-
-	return 'GTM-K5GL9W';
-
-}
-
-
-/**
- * Adds Google Tag Manager code to <head>
- */
-function uri_tedx_gtm() {
-	$gtm = uri_tedx_gtm_value();
-	if ( ! empty( $gtm ) ) :
-	?>
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','<?php echo $gtm; ?>');</script>
-	<?php
-	endif;
-}
-add_action( 'wp_head', 'uri_tedx_gtm' );
-
-
 /**
  * Enqueue scripts and styles.
  */

--- a/header.php
+++ b/header.php
@@ -26,13 +26,6 @@
 	
 <body <?php body_class(); ?>>
 	
-<?php
-	$gtm = uri_tedx_gtm_value();
-if ( ! empty( $gtm ) ) {
-	echo '<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=' . $gtm . '" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>';
-}
-?>
-	
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'uri' ); ?></a>
 

--- a/js/script.min.js
+++ b/js/script.min.js
@@ -4,13 +4,13 @@ Theme URI: https://www.uri.edu/tedx
 Author: University of Rhode Island
 Author URI: https://today.uri.edu
 Description: The WordPress theme for TEDxURI
-Version: 2.3.0
+Version: 3.0.0
 License: GPL-3.0
 License URI: http://www.gnu.org/licenses/gpl.html
 Text Domain: uri
 Tags: education, theme-options
 
-@version v2.3.0
+@version v3.0.0
 @author Brandon Fuller <bjcfuller@uri.edu>
 
 */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "uri-tedx",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "uri-tedx",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "GPL-3.0",
       "devDependencies": {
         "@wordpress/eslint-plugin": "^9.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uri-tedx",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "The WordPress theme for TEDxURI",
   "themeName": "URI TEDx",
   "textDomain": "uri",

--- a/style.css
+++ b/style.css
@@ -4,13 +4,13 @@ Theme URI: https://www.uri.edu/tedx
 Author: University of Rhode Island
 Author URI: https://today.uri.edu
 Description: The WordPress theme for TEDxURI
-Version: 2.3.0
+Version: 3.0.0
 License: GPL-3.0
 License URI: http://www.gnu.org/licenses/gpl.html
 Text Domain: uri
 Tags: education, theme-options
 
-@version v2.3.0
+@version v3.0.0
 @author Brandon Fuller <bjcfuller@uri.edu>
 
 */


### PR DESCRIPTION
## What's new in 3.0

* Removes Google Tag Manager entirely

> Note: Installing this version without another means of GTM or GA injection will cease all analytics tracking. Think carefully!